### PR TITLE
BUGFIX: Prevent endless recursion in recurring and circular types

### DIFF
--- a/Classes/Resolver.php
+++ b/Classes/Resolver.php
@@ -24,16 +24,22 @@ class Resolver
      */
     public function decorateTypeConfig(array $typeConfig)
     {
-        $fields = $typeConfig['fields']();
-
         $typeConfig['resolveType'] = [$this, 'resolveType'];
-        $typeConfig['fields'] = &$fields;
-        foreach($fields as $name => &$config) {
-            $resolveMethod = [$this, $name];
-            if (is_callable($resolveMethod)) {
-                $config['resolve'] = $resolveMethod;
+        $fields = $typeConfig['fields'];
+
+        $typeConfig['fields'] = function () use ($fields) {
+            $resolvedFields = [];
+            foreach($fields() as $name => $config) {
+                $resolveMethod = [$this, $name];
+                if (is_callable($resolveMethod)) {
+                    $config['resolve'] = $resolveMethod;
+                }
+
+                $resolvedFields[$name] = $config;
             }
-        }
+
+            return $resolvedFields;
+        };
 
         return $typeConfig;
     }

--- a/Classes/SchemaService.php
+++ b/Classes/SchemaService.php
@@ -78,7 +78,7 @@ class SchemaService
         $resolverPathPattern = $endpointConfiguration['resolverPathPattern'] ?? null;
         /** @var Resolver[] $resolvers */
         $resolvers = [];
-        return BuildSchema::build($documentNode, function ($config) use ($resolvers, $resolverConfiguration, $resolverPathPattern) {
+        return BuildSchema::build($documentNode, function ($config) use (&$resolvers, $resolverConfiguration, $resolverPathPattern) {
             $name = $config['name'];
 
             if (!isset($resolvers[$name])) {


### PR DESCRIPTION
The current implementation will run out of memory when using circular types. This pr prevents that.