### PR TITLE
Use url encoded cache key to avoid cache error

### DIFF
--- a/Classes/SchemaService.php
+++ b/Classes/SchemaService.php
@@ -65,13 +65,14 @@ class SchemaService
             return new Schema($schemaConfig);
         }
 
-        if ($this->schemaCache->has($endpoint)) {
-            $documentNode = $this->schemaCache->get($endpoint);
+        $cacheKey = urlencode($endpoint);
+        if ($this->schemaCache->has($cacheKey)) {
+            $documentNode = $this->schemaCache->get($cacheKey);
         } else {
             $schemaPathAndFilename = $endpointConfiguration['schema'];
             $content = Files::getFileContents($schemaPathAndFilename);
             $documentNode = Parser::parse($content);
-            $this->schemaCache->set($endpoint, $documentNode);
+            $this->schemaCache->set($cacheKey, $documentNode);
         }
 
         $resolverConfiguration = $endpointConfiguration['resolvers'] ?? [];


### PR DESCRIPTION
If you use the endpoints with slash e.g. `api/v1` with GraphQL schema, then there is an error from

```
"api/v1" is not a valid cache entry identifier.
Exception Code	1233058486
Exception Type	InvalidArgumentException
Thrown in File	Packages/Libraries/neos/cache/Classes/Frontend/AbstractFrontend.php
Line	100
```