### PR TITLE
Use url encoded cache key to avoid cache error by cache warmup

### DIFF
--- a/Classes/SchemaService.php
+++ b/Classes/SchemaService.php
@@ -162,7 +162,7 @@ class SchemaService
         $schemaPathAndFilename = $this->endpointsConfiguration[$endpoint]['schema'];
         $content = Files::getFileContents($schemaPathAndFilename);
         $documentNode = Parser::parse($content);
-        $this->schemaCache->set($endpoint, $documentNode, [md5($schemaPathAndFilename)]);
+        $this->schemaCache->set(urlencode($endpoint), $documentNode, [md5($schemaPathAndFilename)]);
         return $documentNode;
     }
 


### PR DESCRIPTION
If the endpoints with slash e.g. `api/v1` is used and the command `./flow flow:cache:warmup` is executed, there is still an error:
```
"api/jobs" is not a valid cache entry identifier.

  Type: InvalidArgumentException
  Code: 1233058264
  File: Packages/Libraries/neos/cache/Classes/Frontend/VariableFrontend.php
  Line: 60
```