### PR TITLE
Added support for doctrine toMany relations in AccessibleObject

### DIFF
--- a/Classes/AccessibleObject.php
+++ b/Classes/AccessibleObject.php
@@ -3,7 +3,6 @@ namespace Wwwision\GraphQL;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Utility\ObjectAccess;
-use Doctrine\Common\Collections\Collection;
 
 /**
  * A proxy that exposes all getters of a given object through an ArrayAccess interface
@@ -84,9 +83,9 @@ class AccessibleObject implements \ArrayAccess
             return (boolean)call_user_func([$this->object, $propertyName]);
         }
         $result = ObjectAccess::getProperty($this->object, $propertyName);
-        if ($result instanceof Collection) {
-            return new IterableAccessibleObject($result->toArray());
-        }
+	    if ($result instanceof \IteratorAggregate) {
+		    return new IterableAccessibleObject($result->getIterator());
+	    }
         if (is_array($result) || $result instanceof \Iterator) {
             return new IterableAccessibleObject($result);
         }

--- a/Classes/AccessibleObject.php
+++ b/Classes/AccessibleObject.php
@@ -3,6 +3,7 @@ namespace Wwwision\GraphQL;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Utility\ObjectAccess;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * A proxy that exposes all getters of a given object through an ArrayAccess interface
@@ -83,6 +84,9 @@ class AccessibleObject implements \ArrayAccess
             return (boolean)call_user_func([$this->object, $propertyName]);
         }
         $result = ObjectAccess::getProperty($this->object, $propertyName);
+        if ($result instanceof Collection) {
+            return new IterableAccessibleObject($result->toArray());
+        }
         if (is_array($result) || $result instanceof \Iterator) {
             return new IterableAccessibleObject($result);
         }


### PR DESCRIPTION
Without this change you cannot access ManyToMany or OneToMany doctrine relations as it returns a AccessibleObject instead of a IterableAccessibleObject. This makes it possible to access also toMany relations when wrapping your domain model in AccessibleObject.