### PR TITLE
FEATURE: Type config on schema

### DIFF
--- a/Classes/SchemaService.php
+++ b/Classes/SchemaService.php
@@ -62,6 +62,13 @@ class SchemaService
             if (isset($endpointConfiguration['subscriptionSchema'])) {
                 $schemaConfig->setSubscription($this->typeResolver->get($endpointConfiguration['subscriptionSchema']));
             }
+            if (isset($endpointConfiguration['configTypes'])) {
+                $configTypes = $endpointConfiguration['configTypes'];
+                array_walk($configTypes, function (&$configType) {
+                    $configType = $this->typeResolver->get($configType);
+                });
+                $schemaConfig->setTypes($configTypes);
+            }
             return new Schema($schemaConfig);
         }
 


### PR DESCRIPTION
Hi,

When using interfaces but never referencing the implemented types in the schema, the concrete types are not scanned and therefore not know to the schema. As a solution those types can be loaded via the type config. 

Settings:
```
Wwwision:
  GraphQL:
    endpoints:
      graphql:
        configTypes:
          - Foo\Bar\Type\Object\HumanType
          - Foo\Bar\Type\Object\DroidType
```

Does this implementation make sense in the context of this package? Any suggestion for improvement?

The problem is also described here: https://github.com/webonyx/graphql-php/issues/99