### PR TITLE
BUGFIX: Fix typo in configuration

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,7 +4,7 @@ Neos:
       middlewares:
         redirect:
           position: 'before routing'
-          middleware: 'Wwwision\GraphQL\Http\HttpOptionsMidleware'
+          middleware: 'Wwwision\GraphQL\Http\HttpOptionsMiddleware'
 
 Wwwision:
   GraphQL:


### PR DESCRIPTION
The classname of the middleware in the configuration was a single character off. Sorry for that.