### PR TITLE
BUGFIX: Use unique name for middleware configuration to avoid conflict with neos/resdirecthandler

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,7 +2,7 @@ Neos:
   Flow:
     http:
       middlewares:
-        graphQlOptions:
+        'Wwwision.GraphQL:Options':
           position: 'before routing'
           middleware: 'Wwwision\GraphQL\Http\HttpOptionsMiddleware'
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,7 +2,7 @@ Neos:
   Flow:
     http:
       middlewares:
-        redirect:
+        graphQlOptions:
           position: 'before routing'
           middleware: 'Wwwision\GraphQL\Http\HttpOptionsMiddleware'
 


### PR DESCRIPTION
Since both packages registered a `redirect` middleware only one could win.